### PR TITLE
add UMD wrapping to provide esprima dependency

### DIFF
--- a/lib/esmorph.js
+++ b/lib/esmorph.js
@@ -23,9 +23,24 @@
 */
 
 /*jslint node:true browser:true */
-/*global esmorph:true,esprima:true */
+/*global define:true,esmorph:true,esprima:true */
 
-(function (exports) {
+(function (root, factory) {
+    'use strict';
+
+    if (typeof exports === 'object') {
+        // CommonJS
+        factory(exports, require('esprima'));
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['exports', 'esprima'], function (exports, esprima) {
+            factory((root.esmorph = exports), esprima);
+        });
+    } else {
+        // Browser globals
+        factory((root.esmorph = {}), root.esprima);
+    }
+}(this, function (exports, esprima) {
     'use strict';
 
     var Syntax = {
@@ -237,4 +252,5 @@
         FunctionEntrance: traceFunctionEntrance
     };
 
-}(typeof exports === 'undefined' ? (esmorph = {}) : exports));
+}));
+


### PR DESCRIPTION
This commit wraps the esmorph module in the UMD commonjsStrictGlobal template so that it can be require'd in node as well as added as a property to the global in a browser with no AMD loader available. 
