### PR TITLE
Fix esmorph.js:134 TypeError: code.slice(...).replace is not a function

### DIFF
--- a/lib/esmorph.js
+++ b/lib/esmorph.js
@@ -130,7 +130,7 @@
                 parent = path[0];
                 if (parent.type === esprima.Syntax.AssignmentExpression) {
                     if (typeof parent.left.range !== 'undefined') {
-                        name = code.slice(parent.left.range[0], parent.left.range[1]).replace(/"/g, '\\"');
+                        name = code.toString().slice(parent.left.range[0], parent.left.range[1]).replace(/"/g, '\\"');
                     }
                 } else if (parent.type === esprima.Syntax.VariableDeclarator) {
                     name = parent.id.name;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "url": "http://github.com/ariya/esmorph/raw/master/LICENSE.BSD"
     }],
     "dependencies": {
-       "esprima": "~1.2.2"
+       "esprima": "2.7.2"
     },
     "devDependencies": {
         "jslint": "~0.1.9",


### PR DESCRIPTION
Tried to morph a file and got this error:

``` javascript
name = code.slice(parent.left.range[0], parent.left.range[1]).replace(/"/g, '\\"');
TypeError: code.slice(...).replace is not a function
    at /home/kaartje2go/webapplications/trace/node_modules/esmorph/lib/esmorph.js:134:87
```
